### PR TITLE
Delete obsolete Python 3.7 exclude for Windows and MacOS

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -26,8 +26,6 @@ jobs:
         # test only the latest 3.x on windows
         exclude:
           - os: macos-latest
-            python-version: '3.7'
-          - os: macos-latest
             python-version: '3.8'
           - os: macos-latest
             python-version: '3.9'
@@ -35,8 +33,6 @@ jobs:
             python-version: '3.10'
           - os: macos-latest
             python-version: '3.11'
-          - os: windows-latest
-            python-version: '3.7'
           - os: macos-latest
             python-version: '3.12'
           - os: windows-latest

--- a/changelogs/master/summary.md
+++ b/changelogs/master/summary.md
@@ -16,6 +16,11 @@ The package is now running on and tested against Python 3.13.
 
 # Refactored
 
+## Refactored GitHub Actions [#9](https://github.com/imaug/imaug/pull/9)
+
+* Deleted an obsolete Python 3.7 exclude in `test_pull_request.yml`. [#9](https://github.com/imaug/imaug/pull/9)
+
+
 # Fixed
 
 # Improved


### PR DESCRIPTION
The workflow does not test Python 3.7 anymore. Therefore, any exclude of it is obsolete.