### PR TITLE
bugfix: FigureCanvasAgg has no set_window_title

### DIFF
--- a/changelogs/master/summary.md
+++ b/changelogs/master/summary.md
@@ -24,5 +24,6 @@ The package is now running on and tested against Python 3.13.
 # Fixed
 
 * Fixed old version string. [#11](https://github.com/imaug/imaug/pull/11)
+* Fixed removed `set_window_title`in `imshow`.
 
 # Improved

--- a/changelogs/master/summary.md
+++ b/changelogs/master/summary.md
@@ -24,6 +24,6 @@ The package is now running on and tested against Python 3.13.
 # Fixed
 
 * Fixed old version string. [#11](https://github.com/imaug/imaug/pull/11)
-* Fixed removed `set_window_title`in `imshow`.
+* Fixed matplotlib's removed `set_window_title` in `imshow`. [#12](https://github.com/imaug/imaug/pull/12)
 
 # Improved

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -1966,7 +1966,7 @@ def imshow(image, backend=IMSHOW_BACKEND_DEFAULT):
         w = max(w, 6)
 
         fig, ax = plt.subplots(figsize=(w, h), dpi=dpi)
-        fig.canvas.set_window_title("imgaug.imshow(%s)" % (image.shape,))
+        fig.canvas.manager.set_window_title("imgaug.imshow(%s)" % (image.shape,))
         # cmap=gray is automatically only activate for grayscale images
         ax.imshow(image, cmap="gray")
         plt.show()


### PR DESCRIPTION
Matplotlib >= 3.6.0 [removed](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.6.0.html#classes-methods-and-attributes) `FigureCanvas.set_window_title()` from it's API.

As an alternative [FigureManagerBase.set_window_title](https://matplotlib.org/stable/api/backend_bases_api.html#matplotlib.backend_bases.FigureManagerBase.set_window_title) should be used and is supported for ealier versions.