### PR TITLE
Fix clip out image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,7 @@ kilsenp             Pfeiffer, Kilian
 AlexanderRagnarsson Ragnarsson*, Alexander*
 creinders           Reinders, Christoph
 ZhengRui            Rui, Zheng
+ranshadmi           Shadmi, Ran
 stnk20              Tanaka, Satoshi
 vallentin           Vallentin, Christian
 gaborvecsei         Vecsei, Gábor
@@ -1262,6 +1263,7 @@ If this library has helped you during your research, feel free to cite it:
             and Ragnarsson, Alexander
             and Reinders, Christoph
             and Rui, Zheng
+            and Shadmi, Ran
             and Tanaka, Satoshi
             and Vallentin, Christian
             and Vecsei, Gábor

--- a/changelogs/master/summary.md
+++ b/changelogs/master/summary.md
@@ -25,5 +25,6 @@ The package is now running on and tested against Python 3.13.
 
 * Fixed old version string. [#11](https://github.com/imaug/imaug/pull/11)
 * Fixed matplotlib's removed `set_window_title` in `imshow`. [#12](https://github.com/imaug/imaug/pull/12)
+* Fixed `shapely.geometry.GeometryCollection` handling in `Polygon.clip_out_of_image`. [#13](https://github.com/imaug/imaug/pull/13)
 
 # Improved

--- a/changelogs/master/summary.md
+++ b/changelogs/master/summary.md
@@ -23,4 +23,6 @@ The package is now running on and tested against Python 3.13.
 
 # Fixed
 
+* Fixed old version string. [#11](https://github.com/imaug/imaug/pull/11)
+
 # Improved

--- a/imgaug/__init__.py
+++ b/imgaug/__init__.py
@@ -13,4 +13,4 @@ import imgaug.parameters as parameters
 import imgaug.dtypes as dtypes
 import imgaug.data as data
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/test/augmentables/test_polys.py
+++ b/test/augmentables/test_polys.py
@@ -859,6 +859,34 @@ class TestPolygon_clip_out_of_image(unittest.TestCase):
         assert isinstance(multipoly_clipped, list)
         assert len(multipoly_clipped) == 0
 
+    def test_polygon_with_point_and_rectangle_inside_image(self):
+        # square with line polygon,
+        # but rectangle with point are inside the image
+        poly = ia.Polygon([
+            (10, 15), (0, 10), # line
+            (10, 15), (10, 5), (20, 5), (20, 15) # square
+        ])
+        multipoly_clipped = poly.clip_out_of_image((10, 20, 3))
+        assert isinstance(multipoly_clipped, list)
+        assert len(multipoly_clipped) == 1
+        assert multipoly_clipped[0].exterior_almost_equals(np.float32([
+            (10, 10), (10,  5), (20,  5), (20, 10) # rectangle
+        ]))
+
+    def test_polygon_with_line_and_rectangle_inside_image(self):
+        # square with line polygon,
+        # but rectangle with line are inside the image
+        poly = ia.Polygon([
+            (10, 15), (0, 5), # line
+            (10, 15), (10, 5), (20, 5), (20, 15) # square
+        ])
+        multipoly_clipped = poly.clip_out_of_image((10, 20, 3))
+        assert isinstance(multipoly_clipped, list)
+        assert len(multipoly_clipped) == 1
+        assert multipoly_clipped[0].exterior_almost_equals(np.float32([
+            (10, 10), (10,  5), (20,  5), (20, 10) # rectangle
+        ]))
+
 
 class TestPolygon_shift_(unittest.TestCase):
     @property

--- a/test/test_imgaug.py
+++ b/test/test_imgaug.py
@@ -1540,8 +1540,6 @@ def test_draw_grid():
         assert grid.dtype == np.dtype(dtype)
         assert _allclose(grid, expected)
 
-# TODO(erjel): Add ia.imshow test!
-
 
 def test_classes_and_functions_marked_deprecated():
     import imgaug.imgaug as iia

--- a/test/test_imgaug.py
+++ b/test/test_imgaug.py
@@ -1540,6 +1540,8 @@ def test_draw_grid():
         assert grid.dtype == np.dtype(dtype)
         assert _allclose(grid, expected)
 
+# TODO(erjel): Add ia.imshow test!
+
 
 def test_classes_and_functions_marked_deprecated():
     import imgaug.imgaug as iia


### PR DESCRIPTION
Use commit  d173fd0 by @ranshadmi to fix issue with `Polygon.clip_out_of_image` in this fork.

The problem is caused by the false assumption that `shapely.intersection` only returns `shapely.GeometryCollection` if the polygon is completely outside the image. Yet, this is also the case if it results in a polygon and another geometry.