### PR TITLE
Added functionality for low , medium and high fog options 

### DIFF
--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -738,17 +738,16 @@ class LowFog(CloudLayer):
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
         super(LowFog, self).__init__(
-            intensity_mean=(230, 255),              # high brightness
-            intensity_freq_exponent=(-1.8, -1.5),   # soft patterns
-            intensity_coarse_scale=1.5,
-            alpha_min=(0.6, 0.8),                   # more visible minimum fog
-            alpha_multiplier=0.5,                   # stronger fog overlay
-            alpha_size_px_max=(6, 10),
-            alpha_freq_exponent=(-2.5, -2.0),
-            sparsity=0.8,                           # denser cloud mask
-            density_multiplier=(0.6, 0.8),          # much stronger overall fog
-            seed=seed, name=name,
-            random_state=random_state, deterministic=deterministic
+            intensity_mean=(240, 255),
+            intensity_freq_exponent=(-1.2, -1.0),
+            intensity_coarse_scale=3,
+            alpha_min=0.9,
+            alpha_multiplier=1.2,
+            alpha_size_px_max=(2, 4),
+            alpha_freq_exponent=(-3.0, -2.0),
+            sparsity=0.2,
+            density_multiplier=1.5,
+            seed=seed
         )
 
 


### PR DESCRIPTION
Straightforward use of functions to also enable low , medium and high fog transitions that might help users. 

Use Case - 
aug1 = iaa.LowFog()
aug2 = iaa.MediumFog()
aug3 = iaa.HighFog()

augmented_image1 = aug1(image=image)
augmented_image2 = aug2(image=image)
augmented_image3 = aug3(image=image)
# print(augmented_image)

ia.imshow(image)
ia.imshow(augmented_image1)
ia.imshow(augmented_image2)
ia.imshow(augmented_image3)

code for reading, augmenting and printing images with fog transitions. 


default Fog code is commented out , to avoid confusion, comment can be removed by users as required to switch to default use of function. 