### PR TITLE
fix: replace old version string

### DIFF
--- a/changelogs/master/summary.md
+++ b/changelogs/master/summary.md
@@ -14,4 +14,6 @@
 
 # Fixed
 
+## Correct the `__version__` string [#18](https://github.com/imaug/imaug/pull/18)
+
 # Improved

--- a/imgaug/__init__.py
+++ b/imgaug/__init__.py
@@ -13,4 +13,4 @@ import imgaug.parameters as parameters
 import imgaug.dtypes as dtypes
 import imgaug.data as data
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'


### PR DESCRIPTION
The latest release forgot to update the "__version__" property